### PR TITLE
[DEVOPS-1131] Bump kubernetes-model from 0.2.10 to 0.2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>io.alauda</groupId>
       <artifactId>kubernetes-model</artifactId>
-      <version>0.2.10</version>
+      <version>0.2.11-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -393,6 +393,7 @@
       <artifactId>json</artifactId>
       <version>${org.json.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>


### PR DESCRIPTION
Upstream list:

* https://bitbucket.org/mathildetech/devops-apiserver/pull-requests/335/devops-1131-add-raw-jenkins-agent/diff
* https://bitbucket.org/mathildetech/kubernetes-model/pull-requests/16/update-pipelinetemplate-new-field-raw-in/diff#chg-vendor/alauda.io/devops-apiserver/pkg/apis/devops.alauda.io/types_base.go