### PR TITLE
[DEVOPS-3338] disable shallow clone by default

### DIFF
--- a/src/main/java/io/alauda/jenkins/devops/sync/mapper/converter/GitProviderMultiBranch.java
+++ b/src/main/java/io/alauda/jenkins/devops/sync/mapper/converter/GitProviderMultiBranch.java
@@ -43,7 +43,7 @@ public interface GitProviderMultiBranch extends ExtensionPoint {
    *     honorRefspec: true<br>
    */
   default CloneOptionTrait getCloneTrait() {
-    CloneOption cloneOption = new CloneOption(true, false, null, null);
+    CloneOption cloneOption = new CloneOption(false, false, null, null);
     cloneOption.setHonorRefspec(true);
 
     return new CloneOptionTrait(cloneOption);


### PR DESCRIPTION
The corresponding hotfix on 2.6 is #224
The corresponding hotfix on 1.8 is #225