### PR TITLE
Fix some problems that pipeline is always in queue

### DIFF
--- a/src/main/java/io/alauda/jenkins/devops/sync/client/JenkinsClient.java
+++ b/src/main/java/io/alauda/jenkins/devops/sync/client/JenkinsClient.java
@@ -425,6 +425,11 @@ public class JenkinsClient {
 
       // try to cancel the build if it is in the queue
       if (buildInQueue.isPresent()) {
+        logger.debug(
+            "canceling build: %s,  pipeline: %s/%s  in queue",
+            buildInQueue.get().getDisplayName(),
+            pipelineNamespaceName.getNamespace(),
+            pipelineNamespaceName.getName());
         if (pipelineQueue.cancel(buildInQueue.get())) {
           return;
         } else {
@@ -473,10 +478,22 @@ public class JenkinsClient {
           if (run.hasntStartedYet() || run.isBuilding()) {
             terminateRun(run);
             return true;
+          } else {
+            logger.debug(
+                String.format(
+                    "run hasStartedYet:%s, isBuilding:%s, run: %s",
+                    run.hasntStartedYet(),
+                    run.isBuilding(), run.getFullDisplayName()));
           }
         }
       }
     }
+
+    logger.debug(
+        String.format(
+            "has no run in current builds of this pipeline: %s/%s",
+            namespaceName.getNamespace(),
+            namespaceName.getName()));
     return false;
   }
 
@@ -489,6 +506,7 @@ public class JenkinsClient {
                 @Override
                 public void doRun() {
                   try (ACLContext ignore = ACL.as(ACL.SYSTEM)) {
+                    logger.debug("terminate run: {}, doKill", run.getFullDisplayName());
                     run.doKill();
                   }
                 }

--- a/src/main/java/io/alauda/jenkins/devops/sync/constants/Constants.java
+++ b/src/main/java/io/alauda/jenkins/devops/sync/constants/Constants.java
@@ -171,6 +171,10 @@ public final class Constants {
   public static final String PIPELINECONFIG_KIND = "pipeline.kind";
   public static final String PIPELINE_CONFIG_LABEL_TEMPLATE = "templateName";
 
+  public static final Supplier ANNOTATION_PIPELINE_CANCEL_RETRY =
+      ResourceControllerManager.getControllerManager()
+          .getFormattedAnnotation("pipeline-cancel-retry");
+
   public static final String GITHUB_SCM_SOURCE =
       "org.jenkinsci.plugins.github_branch_source.GitHubSCMSource";
   public static final String GITHUB_BRANCH_DISCOVERY_TRAIT =


### PR DESCRIPTION
1. add logic of hack to abort build when cancel is not worked
2. change to failure when jenkins lost queue data and the pipeline status is queued and no run in jenkins

Signed-off-by: jtcheng <jtcheng@alauda.io>